### PR TITLE
Snake case

### DIFF
--- a/src/service/formatters/keys.go
+++ b/src/service/formatters/keys.go
@@ -8,15 +8,15 @@ import (
 func FormatKeyResponse(key *entities.Key) *logical.Response {
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"id":        key.ID,
-			"curve":     key.Curve,
-			"algorithm": key.Algorithm,
-			"publicKey": key.PublicKey,
-			"namespace": key.Namespace,
-			"tags":      key.Tags,
-			"version":   key.Version,
-			"createdAt": key.CreatedAt,
-			"updatedAt": key.UpdatedAt,
+			"id":         key.ID,
+			"curve":      key.Curve,
+			"algorithm":  key.Algorithm,
+			"public_key": key.PublicKey,
+			"namespace":  key.Namespace,
+			"tags":       key.Tags,
+			"version":    key.Version,
+			"created_at": key.CreatedAt,
+			"updated_at": key.UpdatedAt,
 		},
 	}
 }

--- a/src/service/keys/create_test.go
+++ b/src/service/keys/create_test.go
@@ -74,7 +74,7 @@ func (s *keysCtrlTestSuite) TestKeysController_Create() {
 		response, err := createOperation.Handler()(s.ctx, request, data)
 
 		assert.NoError(t, err)
-		assert.Equal(t, key.PublicKey, response.Data["publicKey"])
+		assert.Equal(t, key.PublicKey, response.Data["public_key"])
 		assert.Equal(t, key.Namespace, response.Data["namespace"])
 		assert.Equal(t, key.Algorithm, response.Data["algorithm"])
 		assert.Equal(t, key.Curve, response.Data["curve"])

--- a/src/service/keys/get_test.go
+++ b/src/service/keys/get_test.go
@@ -58,14 +58,14 @@ func (s *keysCtrlTestSuite) TestKeysController_Get() {
 		response, err := getOperation.Handler()(s.ctx, request, data)
 
 		assert.NoError(t, err)
-		assert.Equal(t, key.PublicKey, response.Data["publicKey"])
+		assert.Equal(t, key.PublicKey, response.Data["public_key"])
 		assert.Equal(t, key.Namespace, response.Data["namespace"])
 		assert.Equal(t, key.Algorithm, response.Data["algorithm"])
 		assert.Equal(t, key.Curve, response.Data["curve"])
 		assert.Equal(t, key.ID, response.Data["id"])
 		assert.Equal(t, key.Tags, response.Data["tags"])
-		assert.NotNil(t, key.Tags, response.Data["createdAt"])
-		assert.NotNil(t, key.Tags, response.Data["updatedAt"])
+		assert.NotNil(t, key.Tags, response.Data["created_at"])
+		assert.NotNil(t, key.Tags, response.Data["updated_at"])
 		assert.Equal(t, 1, response.Data["version"])
 	})
 

--- a/src/service/keys/import_test.go
+++ b/src/service/keys/import_test.go
@@ -87,7 +87,7 @@ func (s *keysCtrlTestSuite) TestEthereumController_Import() {
 
 		assert.NoError(t, err)
 		assert.Equal(t, key.ID, response.Data["id"])
-		assert.Equal(t, key.PublicKey, response.Data["publicKey"])
+		assert.Equal(t, key.PublicKey, response.Data["public_key"])
 		assert.Equal(t, key.Namespace, response.Data["namespace"])
 		assert.Equal(t, key.Curve, response.Data["curve"])
 		assert.Equal(t, key.Algorithm, response.Data["algorithm"])

--- a/src/vault/entities/key.go
+++ b/src/vault/entities/key.go
@@ -6,11 +6,11 @@ type Key struct {
 	ID         string            `json:"id"`
 	Curve      string            `json:"curve"`
 	Algorithm  string            `json:"algorithm"`
-	PrivateKey string            `json:"privateKey"`
-	PublicKey  string            `json:"publicKey"`
+	PrivateKey string            `json:"private_key"`
+	PublicKey  string            `json:"public_key"`
 	Namespace  string            `json:"namespace,omitempty"`
 	Tags       map[string]string `json:"tags,omitempty"`
-	CreatedAt  time.Time         `json:"createdAt"`
-	UpdatedAt  time.Time         `json:"updatedAt"`
+	CreatedAt  time.Time         `json:"created_at"`
+	UpdatedAt  time.Time         `json:"updated_at"`
 	Version    int               `json:"version"`
 }


### PR DESCRIPTION
Change camel case to snake case for keys (not for ethereum and zk-snarks to avoid breaking change).